### PR TITLE
Add custom author link for @MonikaFu

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -36,3 +36,5 @@ authors:
     href: https://github.com/cjyetman
   Mauro Lepore:
     href: https://github.com/maurolepore
+  Monika Furdyna:
+    href: https://github.com/MonikaFu


### PR DESCRIPTION
This is so when you use this template and @MonikaFu is a listed author/developer, her name will link to her GitHub page like this
<img width="221" alt="Screen Shot 2022-03-10 at 13 31 10" src="https://user-images.githubusercontent.com/1708872/157662473-b06cc55a-0775-4b42-a02b-27186ac84600.png">

instead of being un-clickable text like this
<img width="265" alt="Screen Shot 2022-03-10 at 13 31 22" src="https://user-images.githubusercontent.com/1708872/157662548-a80a9868-25f6-4423-80f3-2b068acd4bc9.png">
